### PR TITLE
Document how to apply a label using the issue description

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,6 +243,7 @@
 </p><p>If the horizontal group believes that an issue with a <i class="term">*-tracker</i> label needs to be resolved before a transition, they may apply a <i class="term">*-needs-resolution</i> label to the issue. Automatic tooling will later remove the <i class="term">*-tracker</i> label.</p>
  <p>If you close an issue with a <i class="term">*-tracker</i> or <i class="term">*-needs-resolution</i> label attached, do not remove the label.  Keeping the label maintains the tracking if the issue is reopened, but also provides potentially useful information about what was tracked. (Closed issues in your repository have no effect on tools that check for unresolved issues.)</p>
  <p>At the end of a review, and before attempting to transition the spec, you should clarify that a resolution is described for all of the issues with a <i class="term">*-needs-resolution</i> label, and check that the horizontal group is aware of those resolutions. You don't have to do this for issues with the <i class="term">*-tracker</i> label. (The horizontal group was only tracking those issues, not expecting a particular resolution.)</p>
+ <p>Note that the label may be applied by setting it directly on the issue if you have proper rights, or by appending it preceded with a PLUS sign (+) in the issue description, +<i class="term">*-tracker</i> or +<i class="term">*-needs-resolution</i>.</p>
 </section>
 
 


### PR DESCRIPTION
This document the change in https://github.com/w3c/horizontal-issue-tracker/commit/11752cd30a4a92f6516be3ce0eb050c72d9e51c4

Note that it has been deactivated on purpose for a11y-needs-resolution:
 https://github.com/w3c/horizontal-issue-tracker/commit/707ca231202779475b8027958cc54bc5d4115779
