### PR TITLE
Clarify that this is about wide review, and contains horizontal revie…

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,23 @@
 
 
 
+
+<section id="who_to_ask_for_review">
+<h2>Who to ask for review?</h2>
+ 
+<ul>
+<li> Groups listed in the WG's charter, especially those who manage dependencies.</li>
+<li> Groups jointly responsible for a particular document (if any)  (duh!).</li>
+<li> All horizontal groups listed below.  If it appears that one of those is not relevant (and is not listed in your charter), talk to them informally to confirm that.</li>
+<li> Other groups, at your discretion, even if not in the WG charter: including other W3C groups, external organizations and SSOs, implementers, application developers, etc.</li>
+</ul>
+<p>Use <a rel="nofollow" class="external text" href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a> for general announcements regarding wide and horizontal reviews. <em>However, note that sending an email to this list alone is not sufficient to trigger horizontal reviews. You will still need to formally request review from the Horizontal Groups, as described below.</em></p>
+</section>
+
+
+
+
+
 <section id="how_to_get_horizontal_review">
 <h2><a href="#how_to_get_horizontal_review">How to get horizontal review</a></h2>
 <p>When you have published a First Public Working Draft, you should work through available "self-review" materials and request review of your results in at least the following areas. <em>Long enough</em> before you request a transition to CR, you should do the same again, identifying substantive specification changes since the first review. </p><p>The meaning of "Long enough" depends on how many changes there are, how clearly you have explained them, and how much discussion is needed to resolve issues. Pointing to 14 concise points for a small spec means a short time if they are simple fixes, pointing to 900 diffs from commits and hoping people understand them in a 300 page spec means it will take a <strong>long</strong> time to get review, and potentially a long time to also discuss and agree on how to solve the issues. If you have effectively identified issues for review during development and received feedback on them, the review time will probably be shorter. Horizontal review groups sometimes get bogged down; planning in advance is useful.</p>
@@ -141,53 +158,24 @@
 <li> <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552">Guidelines for Writing RFC Text on Security Considerations (RFC3552)</a>, particularly <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552#section-5">Section 5</a></li></ul></li></ul>
 </details>
 </dd>
-
-
-
-
-<dt>Groups listed in your charter</dt>
-<dd>If there are groups listed in your charter as depending on some specification, you should ask them too.</dd>
-
-
-
-<dt> General announcement</dt>
-<dd>Use <a rel="nofollow" class="external text" href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a> for general announcements regarding wide and horizontal reviews. (Sending an email to this list alone is not sufficient to trigger horizontal reviews. You will still need to formally request review from the Horizontal Groups, as described above.)</dd>
 </dl>
 
 <p>You should familiarize yourself with the rest of this document. This section is just a quick reminder for when you are in the middle of doing the work.</p>
+<p>Recognize that horizontal review groups may be resource limited and may only be able to do one review or may have difficulty scheduling your review quickly.  Give them as much time as you can, consistent with asking for review while it is still reasonable to change the technology to accommodate the issues they find.</p>
 </section>
 
 
 
-
-
-<section id="considerations_and_best_practices">
-<h2><a href="#considerations_and_best_practices">Considerations and best practices</a></h2>
-<p>Among the considerations and best practices, regardless of the <em>type of review</em> (early, thorough wide review, etc.) are:
-</p>
-
- <section id="who_to_ask_for_review">
- <h3>Who to ask for review?</h3>
-<ul>
-<li> Groups listed in the WG's charter</li>
-<li> Groups jointly responsible for a particular document (if any)  (duh!)</li>
-<li> All horizontal groups listed above.  If it appears that one of those is not relevant (and is not listed in your charter), talk to them informally to confirm that.</li>
-<li> Other groups in your discretion, even if not in the WG charter: other W3C groups, external organizations and SSOs, implementers, application developers, etc.</li>
-</ul>
-</section>
 
 
 <section id="when_should_review_be_requested">
-<h3>When should review be requested?</h3>
+<h2>When should review be requested?</h2>
 <ul>
 <li>For most documents, after a <em>First Public Working Draft</em> is published</li>
 <li> Process-2019 requires wide review before a document is published at CR (Candidate Recommendation)</li>
 <li> When a document is both reasonably stable and still flexible enough to allow changes where issues are identified</li>
 <li> When new features are added after a document has already gotten wide review (perhaps requesting a review limited to the new features)</li>
 </ul>
-</section>
-
-<p>Recognize that horizontal review groups may be resource limited and may only be able to do one review or may have difficulty scheduling your review quickly.  Give them as much time as you can, consistent with asking for review while it is still reasonable to change the technology to accommodate the issues they find.</p>
 </section>
 
 


### PR DESCRIPTION
…w sections.

- Move "Who to ask for a review?" just after intro, and add to it the para about public-review-announce
- Raise the level of "When should review be requested?" 
- Remove the "Considerations and best practices" heading.
- Rationalise redundant "Groups listed in your charter" item in blue-backed list

This addresses the main request of https://github.com/w3c/Guide/issues/276