### PR TITLE
Remove section: Request for Comments (RfC) Template

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,42 +156,6 @@
 
 
 
-<section id="rfc_template">
-<h2><a href="#rfc_template">Request for Comments (RfC) Template</a></h2>
-
-<p>The Internationalization WG has a <a rel="nofollow" class="external text" href="https://github.com/w3c/i18n-request/issues/new/choose">series of issue templates</a> that guide you through the information you need to provide when requesting a review.  The information that follows is for other HR groups that don't use that approach.
-</p>
-
-<section id="what_to_include">
-<h3>What to include</h3>
-
-<ul>
-<li>Name of the group seeking comments</li>
-<li>Preferred timeline for comments</li>
-<li>Preferred forum for comments (e.g. a github link or the group's mailing list)</li>
-<li>Suggested: Set the <code>Reply-to:</code> header to the group's mailing list</li>
-<li>Document title(s)</li>
-<li>Document URL(s)</li>
-<li>Maturity Level</li>
-<li>Scope of the requested review: this can be the entire document, specific sections, specific issues, etc.  </li>
-<li>If a review was previously requested, include a human-authored summary of the changes as well as a link to a diff
-<ul><li> <a rel="nofollow" class="external text" href="https://services.w3.org/htmldiff">W3C's HTML Diff service</a> might be useful</li></ul></li>
-</ul>
-</section>
-
-
-
-<section id="Example_Request_for_Comments">
-<h3>Example Request for Comments</h3>
-<p>Here are some example RfCs:</p>
-<ul><li> <a rel="nofollow" class="external text" href="https://lists.w3.org/Archives/Public/public-html/2014Sep/0099.html">TTML Text and Imaging ... preCR</a></li>
-<li> <a rel="nofollow" class="external text" href="https://lists.w3.org/Archives/Public/public-review-announce/2014Nov/0002.html">Pointer Events LCWD</a></li></ul>
-</section>
-</section>
-
-
-
-
 <section id="working_with_horizontal_review_labels">
 <h2><a href="#working_with_horizontal_review_labels">Working with Horizontal Review labels</a></h2>
 


### PR DESCRIPTION
This appears to be no longer needed, given that all instructions for contacting horizontal groups now have a link to a GitHub issue, which should be used to raise requests, and which contains the template.