### PR TITLE
Clarify that HR is a subset of wide review, and compact content

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,25 +21,19 @@
 
 
 
-<section id="introduction">
-<h2>Introduction</h2>
-
-<p>Getting early review and feedback is important, especially reviews from those groups that have identified a document as a dependency and the <i class="term">horizontal groups</i>. It is also important to get review from other stakeholders including Web developers, technology providers and implementers not active in the Working Group, external groups and standards organizations working on related areas, etc.</p>
-<p>In Process-2019, the focus is on getting evidence that wide review has occurred.</p>
-</section>
-
-
 
 
 
 <section id="who_to_ask_for_review">
 <h2>Who to ask for review?</h2>
  
+<p>Much of this document focuses on how and when to conduct horizontal reviews, but they are only a subset of a full wide review, which must also include other stakeholders including Web developers, technology providers and implementers not active in the Working Group, external groups and standards organizations working on related areas, etc. Here is a list of suggestions:</p>
 <ul>
 <li> Groups listed in the WG's charter, especially those who manage dependencies.</li>
 <li> Groups jointly responsible for a particular document (if any)  (duh!).</li>
-<li> All horizontal groups listed below.  If it appears that one of those is not relevant (and is not listed in your charter), talk to them informally to confirm that.</li>
-<li> Other groups, at your discretion, even if not in the WG charter: including other W3C groups, external organizations and SSOs, implementers, application developers, etc.</li>
+<li> All horizontal groups (listed below).  If it appears that one of those is not relevant (and is not listed in your charter), talk to them informally to confirm that.</li>
+<li> Other groups, at your discretion, even if not in the WG charter, including other W3C groups, external organizations and SSOs, implementers, application developers, etc.</li>
+<li>The general public. Consider using blog posts, social media, or other ways of alerting the public to your document and requesting feedback.</li>
 </ul>
 <p>Use <a rel="nofollow" class="external text" href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a> for general announcements regarding wide and horizontal reviews. <em>However, note that sending an email to this list alone is not sufficient to trigger horizontal reviews. You will still need to formally request review from the Horizontal Groups, as described below.</em></p>
 </section>


### PR DESCRIPTION
Make it clearer that the majority of this doc only addresses a subset of wide review, per https://github.com/w3c/Guide/issues/276

Add a bullet point recommending that wide review include the general public (see the same issue comment) per the Process doc.

Remove redundancy by incorporating some of the Introduction text in the section "Who to ask for review?", and removing the Introduction in favour of the text already at the top of the doc.