### PR TITLE
Improve wide review handling

### DIFF
--- a/createGitHubIssue.js
+++ b/createGitHubIssue.js
@@ -17,7 +17,7 @@ function createGitHubIssue() {
     return;
   }
 
-  const title = encodeURIComponent('Seek horizontal reviews');
+  const title = encodeURIComponent('Seek wide review');
   const body = encodeURIComponent(generateGitHubIssueBody());
   window.open(`https://github.com/${repo}/issues/new?title=${title}&body=${body}`);
 }
@@ -36,14 +36,18 @@ function generateGitHubIssueBody() {
       return;
     }
 
-    const subContents = [...dd.querySelectorAll('.step')].map(el => `    - [ ] ${el.innerHTML}`);
+    const subContents = [...dd.querySelectorAll('.step')].map(el => `      - [ ] ${el.innerHTML}`);
 
-    return `- ${dt.textContent}\n${subContents.join('\n')}`;
+    return `  - ${dt.textContent}\n${subContents.join('\n')}`;
   });
 
-  return `This is a meta issue to track horizontal review steps for the specification.
-See [How to do wide review](https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review) for details.
+  return `This is a meta issue to track wide review steps for the specification.
+See [How to do wide review](https://www.w3.org/Guide/documentreview/#who_to_ask_for_review) for details.
 
+- [ ] the groups listed in the WG's charter, especially those who manage dependencies
+- [ ] the groups jointly responsible for a particular document (if any).
+- the horizontal groups:
 ${bullets.join('\n')}
+- Other outreach (if applicable)
 `;
 }

--- a/index.html
+++ b/index.html
@@ -81,7 +81,8 @@ Recommendation Snapshot: Payment Request API (Call for Wide Review)</a>).</p>
 <li>the groups listed in the WG's charter, especially those who manage
 dependencies.</li>
 <li>the groups jointly responsible for a particular document (if any).</li>
-<li>the <a href="#how_to_get_horizontal_review">horizontal groups</a>.  If it
+<li>the <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal groups</a>
+using the <a href="#how_to_get_horizontal_review">method described below</a>.  If it
 appears that one of those is not relevant (even if not listed in your charter),
 talk to them informally to confirm that. <em>Note that sending an email to the
 public-review-announce list alone is not sufficient to trigger horizontal

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ offered a reasonable opportunity to review the document.</p>
     of alerting the public to your document and requesting feedback.</li>
 </ul>
 
-<p>In addition, you should consider reaching out to other groups, at your
+<p>In addition, you should consider contacting other groups, at your
 discretion, even if not in the WG charter, including other W3C groups, external
 organizations and SSOs, implementers, application developers, etc.</p>
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
   review.</p>
   </li>
   <li>When a document is both reasonably stable and still flexible enough to
-  allow changes where issues are identified</li>
+  allow changes where issues are identified.</li>
   <li>When new features are added after a document has already gotten wide
   review (perhaps requesting a review limited to the new features)</li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body>
 <h1>How to do Wide Review</h1>
 <p>Getting <i class="term">early</i> and <i class="term">wide</i> review of a document is very important, yet in practice it can be challenging.  This document provides some best practices for getting document review; it does not define explicit mandatory steps.</p>
-<p>This page is linked to from <a rel="nofollow" class="external text" href="https://www.w3.org/Guide/">The Guide</a>. See also the <a href="https://www.w3.org/2020/Process-20200915/#wide-review">Wide Review</a> section in the W3C Process document.</p>
+<p>This page is linked to from <a rel="nofollow" class="external text" href="https://www.w3.org/Guide/">The Guide</a>. See also the <a href="https://www.w3.org/Consortium/Process/#wide-review">Wide Review</a> section in the W3C Process document.</p>
 <p><strong>Feedback on this document is welcome, preferably by <a href="https://github.com/w3c/documentreview/issues">raising an issue</a> or a pull request.</strong></p>
 <div id="toc">
 <h2 class="notoc">Contents</h2>
@@ -21,26 +21,97 @@
 
 
 
+<section id="when_should_review_be_requested">
+  <h2>When should wide review be requested?</h2>
+  <p>A document is available for review from the moment it is first <a
+  href='https://www.w3.org/Consortium/Process/#publishing'>published</a>.
+  Working Groups should <a
+  href='https://www.w3.org/Consortium/Process/#formally-addressed'>formally
+  address</a> any substantive review comment about a technical report in a
+  timely manner.</p>
+  <p>Wide review should or must be requested when:</p>
+  <ul>
+  <li>after a <a href="https://www.w3.org/Consortium/Process/#first-wd">First
+  Public Working Draft</a> is published for most documents.
+  <p>Working Groups are often reluctant to make substantive changes to a mature
+  document, so reviewers should get a chance to send substantive technical
+  reviews as early as possible. This is especially important for <a
+  href="#how_to_get_horizontal_review">horizontal reviews</a>.</p>
+  </li>
+  <li>Before a document gets advanced to <a
+  href="https://www.w3.org/Consortium/Process/#transition-cr">Candidate
+  Recommendation</a> or gets updated as a <a
+  href="https://www.w3.org/Consortium/Process/#update-requests">Candidate
+  Recommendation Snapshot</a>.
+  <p>For those, the <a href="https://www.w3.org/Consortium/Process/">W3C
+  Process</a> requires a Group to show that the specification has received wide
+  review.</p>
+  </li>
+  <li>When a document is both reasonably stable and still flexible enough to
+  allow changes where issues are identified</li>
+  <li>When new features are added after a document has already gotten wide
+  review (perhaps requesting a review limited to the new features)</li>
+  </ul>
+  </section>
 
 
 
 <section id="who_to_ask_for_review">
-<h2>Who to ask for review?</h2>
- 
-<p>Much of this document focuses on how and when to conduct horizontal reviews, but they are only a subset of a full wide review, which must also include other stakeholders including Web developers, technology providers and implementers not active in the Working Group, external groups and standards organizations working on related areas, etc. Here is a list of suggestions:</p>
+<h2>Who to ask for wide review?</h2>
+
+<p>The objective is to ensure that the entire set of stakeholders of the Web
+community, including the general public, have had adequate notice of the
+progress of the Working Group and were able to actually perform reviews of and
+provide comments on the specification. When considering <a
+href='https://www.w3.org/Guide/transitions'>requests to advance the maturity
+level of document</a>, the Director will consider who has been explicitly
+offered a reasonable opportunity to review the document.</p>
+
+<p>In order to include other stakeholders including Web developers, technology
+  providers and implementers not active in the Working Group, external groups and
+  standards organizations working on related areas, etc. you must:</p>
 <ul>
-<li> Groups listed in the WG's charter, especially those who manage dependencies.</li>
-<li> Groups jointly responsible for a particular document (if any)  (duh!).</li>
-<li> All horizontal groups (listed below).  If it appears that one of those is not relevant (and is not listed in your charter), talk to them informally to confirm that.</li>
-<li> Other groups, at your discretion, even if not in the WG charter, including other W3C groups, external organizations and SSOs, implementers, application developers, etc.</li>
-<li>The general public. Consider using blog posts, social media, or other ways of alerting the public to your document and requesting feedback.</li>
+  <li>Publish an updated technical report, with the Status of the Document indicating clearly
+  that you're looking for <em>wide review</em>.
+   <p>Our <a
+    href='https://github.com/w3c/transition-notifier/blob/main/notify.js'>tooling</a>
+    do pick up on publications and propagate to <a
+    href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>
+    automatically (for example, <a
+    href='https://lists.w3.org/Archives/Public/public-review-announce/2021Jun/0008.html'>Candidate
+    Recommendation Snapshot: Payment Request API (Call for Wide Review)</a>).</p>
+  </li>
+  <li>Reach out to the Groups listed in the WG's charter, especially those who
+  manage dependencies.</li>
+  <li>Reach out to the Groups jointly responsible for a particular document (if any).</li>
+  <li>Get reviews from the <a
+    href="#how_to_get_horizontal_review">horizontal groups</a>.</li>
+  <li>Reach out to the general public. Beyond the publication, you do so by:
+    <ol>
+      <li>Sending a dedicated announcement to <a
+      href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>
+      if needed (in case the default notice sent to that list is
+      not enough).
+      </li>
+      <li>Considering using blog posts, social media, or other ways
+    of alerting the public to your document and requesting feedback.</li>
 </ul>
-<p>Use <a rel="nofollow" class="external text" href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a> for general announcements regarding wide and horizontal reviews. <em>However, note that sending an email to this list alone is not sufficient to trigger horizontal reviews. You will still need to formally request review from the Horizontal Groups, as described below.</em></p>
+
+<p>In addition, you should consider reaching out to other groups, at your
+discretion, even if not in the WG charter, including other W3C groups, external
+organizations and SSOs, implementers, application developers, etc.</p>
+
+<p><strong>Tip:</strong> consider tracking your wide review progress using a
+GitHub issue, such as <a href="https://github.com/w3c/sensors/issues/299">issue
+#299 of th Sensors API</a>. You can then simply point the Director to the issue.</p>
+
+
+<p>The reviews provided by the <a
+href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal
+groups</a>, a subset of a full wide review, do receive special attention and
+much of the rest of this document focuses on how and when to conduct horizontal reviews.</p>
+
 </section>
-
-
-
-
 
 <section id="how_to_get_horizontal_review">
 <h2>How to get horizontal review</h2>
@@ -99,8 +170,6 @@
 </details>
 </dd>
 
-
-
 <dt>Privacy</dt>
 <dd>
   <span class="step">Write a "Privacy Considerations" section for your document, taking into account the <a rel="nofollow" class="external text" href="https://w3ctag.github.io/security-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>, <a rel="nofollow" class="external text" href="https://w3c.github.io/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a>, and <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973">RFC6973</a></span> then
@@ -153,24 +222,6 @@
 <p>You should familiarize yourself with the rest of this document. This section is just a quick reminder for when you are in the middle of doing the work.</p>
 <p>Recognize that horizontal review groups may be resource limited and may only be able to do one review or may have difficulty scheduling your review quickly.  Give them as much time as you can, consistent with asking for review while it is still reasonable to change the technology to accommodate the issues they find.</p>
 </section>
-
-
-
-
-
-<section id="when_should_review_be_requested">
-<h2>When should review be requested?</h2>
-<ul>
-<li>For most documents, after a <em>First Public Working Draft</em> is published</li>
-<li> Process-2019 requires wide review before a document is published at CR (Candidate Recommendation)</li>
-<li> When a document is both reasonably stable and still flexible enough to allow changes where issues are identified</li>
-<li> When new features are added after a document has already gotten wide review (perhaps requesting a review limited to the new features)</li>
-</ul>
-</section>
-
-
-
-
 
 <section id="working_with_horizontal_review_labels">
 <h2><a href="#working_with_horizontal_review_labels">Working with Horizontal Review labels</a></h2>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ offered a reasonable opportunity to review the document.</p>
   <li>Reach out to the Groups jointly responsible for a particular document (if any).</li>
   <li><a href="#how_to_get_horizontal_review">Request reviews</a> from the
       <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal groups</a></li>
-  <li>Reach out to the general public. Beyond the publication, you do so by:
+  <li>Actively inform the general public. Beyond the publication, you do so by:
     <ol>
       <li>Sending a dedicated announcement to <a
       href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ offered a reasonable opportunity to review the document.</p>
   </li>
   <li>Inform, and request review from, the Groups listed in the WG's charter, especially those who
   manage dependencies.</li>
-  <li>Reach out to the Groups jointly responsible for a particular document (if any).</li>
+  <li>Inform, and request review from, to the Groups jointly responsible for a particular document (if any).</li>
   <li><a href="#how_to_get_horizontal_review">Request reviews</a> from the
       <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal groups</a></li>
   <li>Actively inform the general public. Beyond the publication, you do so by:

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ automatically (for example, <a
 href='https://lists.w3.org/Archives/Public/public-review-announce/2021Jun/0008.html'>Candidate
 Recommendation Snapshot: Payment Request API (Call for Wide Review)</a>).</p>
 
-<p>You should then reach out to:</p>
+<p>You should then inform, and request reviews from:</p>
 
 <ul>
 <li>the groups listed in the WG's charter, especially those who manage

--- a/index.html
+++ b/index.html
@@ -54,62 +54,67 @@
   </ul>
   </section>
 
-
-
 <section id="who_to_ask_for_review">
 <h2>Who to ask for wide review?</h2>
 
-<p>The objective is to ensure that the entire set of stakeholders of the Web
-community, including the general public, have had adequate notice of the
-progress of the Working Group and were genuinely able to perform reviews of and
-provide comments on the specification. When considering <a
-href='https://www.w3.org/Guide/transitions'>requests to advance the maturity
-level of document</a>, the Director will consider who has been explicitly
-offered a reasonable opportunity to review the document.</p>
+ <p>The objective is to ensure that the entire set of stakeholders of the Web
+ community, including the general public, have  adequate notice of the progress
+ of the Working Group and are able to actually perform reviews of and provide
+ comments on the specification. When considering <a
+ href="https://www.w3.org/Guide/transitions">requests to advance the maturity
+ level of the document</a>, the Director will consider who has been explicitly
+ offered a reasonable opportunity to review the document.</p>
 
-<p>In order to include other stakeholders including Web developers, technology
-  providers and implementers not active in the Working Group, external groups and
-  standards organizations working on related areas, etc. you must:</p>
+<p>You must publish an updated technical report, with the Status of the Document
+indicating clearly that you're looking for <em>wide review</em>, before inviting
+review from other stakeholders. Our <a
+href='https://github.com/w3c/transition-notifier/blob/main/notify.js'>tooling</a>
+monitors publications and propagates notifications to <a
+href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>
+automatically (for example, <a
+href='https://lists.w3.org/Archives/Public/public-review-announce/2021Jun/0008.html'>Candidate
+Recommendation Snapshot: Payment Request API (Call for Wide Review)</a>).</p>
+
+<p>You should then reach out to:</p>
+
 <ul>
-  <li>Publish an updated technical report, with the Status of the Document indicating clearly
-  that you're looking for <em>wide review</em>.
-   <p>Our <a
-    href='https://github.com/w3c/transition-notifier/blob/main/notify.js'>tooling</a>
-    monitors publications and propagates to <a
+<li>the groups listed in the WG's charter, especially those who manage
+dependencies.</li>
+<li>the groups jointly responsible for a particular document (if any).</li>
+<li>the <a href="#how_to_get_horizontal_review">horizontal groups</a>.  If it
+appears that one of those is not relevant (even if not listed in your charter),
+talk to them informally to confirm that. <em>Note that sending an email to the
+public-review-announce list alone is not sufficient to trigger horizontal
+reviews. You will still need to formally request review from the Horizontal
+Groups, as described below</em></li>
+<li>the general public,  including Web developers, technology providers and
+implementers, application developers, etc. Consider:
+  <ul>
+    <li>sending a dedicated announcement to <a
     href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>
-    automatically (for example, <a
-    href='https://lists.w3.org/Archives/Public/public-review-announce/2021Jun/0008.html'>Candidate
-    Recommendation Snapshot: Payment Request API (Call for Wide Review)</a>).</p>
-  </li>
-  <li>Inform, and request review from, the Groups listed in the WG's charter, especially those who
-  manage dependencies.</li>
-  <li>Inform, and request review from, to the Groups jointly responsible for a particular document (if any).</li>
-  <li><a href="#how_to_get_horizontal_review">Request reviews</a> from the
-      <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal groups</a></li>
-  <li>Actively inform the general public. Beyond the publication, you do so by:
-    <ol>
-      <li>Sending a dedicated announcement to <a
-      href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>
-      if needed (in case the default notice sent to that list is
-      not enough).
-      </li>
-      <li>Considering using blog posts, social media, or other ways
-    of alerting the public to your document and requesting feedback.</li>
-</ul>
+    if needed (in case the default notice sent to that list is not enough).</li>
+    <li>using blog posts, social media, or other ways of alerting the public to
+    your document and requesting feedback.</li>
+  </ul>
+</li>
 
-<p>In addition, you should consider contacting other groups, at your
-discretion, even if not in the WG charter, including other W3C groups, external
-organizations and SSOs, implementers, application developers, etc.</p>
+<li>other groups, at your discretion, even if not in the WG charter, such as
+other W3C groups, external organizations and SSOs  working on related areas,
+etc.</li>
+
+</ul>
 
 <p><strong>Tip:</strong> consider tracking your wide review progress using a
 GitHub issue, such as <a href="https://github.com/w3c/sensors/issues/299">issue
-#299 of th Sensors API</a>. You can then simply point the Director to the issue.</p>
+#299 of the Sensors API</a>. You can then simply point the Director to the
+issue.</p>
 
 
 <p>The reviews provided by the <a
 href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal
 groups</a>, a subset of a full wide review, do receive special attention and
-much of the rest of this document focuses on how and when to conduct horizontal reviews.</p>
+much of the rest of this document focuses on how and when to conduct horizontal
+reviews.</p>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ offered a reasonable opportunity to review the document.</p>
   that you're looking for <em>wide review</em>.
    <p>Our <a
     href='https://github.com/w3c/transition-notifier/blob/main/notify.js'>tooling</a>
-    do pick up on publications and propagate to <a
+    monitors publications and propagates to <a
     href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>
     automatically (for example, <a
     href='https://lists.w3.org/Archives/Public/public-review-announce/2021Jun/0008.html'>Candidate

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
   </li>
   <li>When a document is both reasonably stable and still flexible enough to
   allow changes where issues are identified.</li>
-  <li>When new features are added after a document has already gotten wide
+  <li>When new features are added after a document has already received wide
   review (perhaps requesting a review limited to the new features).</li>
   </ul>
   </section>

--- a/index.html
+++ b/index.html
@@ -84,8 +84,8 @@ offered a reasonable opportunity to review the document.</p>
   <li>Inform, and request review from, the Groups listed in the WG's charter, especially those who
   manage dependencies.</li>
   <li>Reach out to the Groups jointly responsible for a particular document (if any).</li>
-  <li>Get reviews from the <a
-    href="#how_to_get_horizontal_review">horizontal groups</a>.</li>
+  <li><a href="#how_to_get_horizontal_review">Request reviews</a> from the
+      <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal groups</a></li>
   <li>Reach out to the general public. Beyond the publication, you do so by:
     <ol>
       <li>Sending a dedicated announcement to <a

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ offered a reasonable opportunity to review the document.</p>
     href='https://lists.w3.org/Archives/Public/public-review-announce/2021Jun/0008.html'>Candidate
     Recommendation Snapshot: Payment Request API (Call for Wide Review)</a>).</p>
   </li>
-  <li>Reach out to the Groups listed in the WG's charter, especially those who
+  <li>Inform, and request review from, the Groups listed in the WG's charter, especially those who
   manage dependencies.</li>
   <li>Reach out to the Groups jointly responsible for a particular document (if any).</li>
   <li>Get reviews from the <a

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   href='https://www.w3.org/Consortium/Process/#formally-addressed'>formally
   address</a> any substantive review comment about a technical report in a
   timely manner.</p>
-  <p>Wide review should or must be requested when:</p>
+  <p>Wide review should or must be requested:</p>
   <ul>
   <li>after a <a href="https://www.w3.org/Consortium/Process/#first-wd">First
   Public Working Draft</a> is published for most documents.

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
   <li>When a document is both reasonably stable and still flexible enough to
   allow changes where issues are identified.</li>
   <li>When new features are added after a document has already gotten wide
-  review (perhaps requesting a review limited to the new features)</li>
+  review (perhaps requesting a review limited to the new features).</li>
   </ul>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body>
 <h1>How to do Wide Review</h1>
 <p>Getting <i class="term">early</i> and <i class="term">wide</i> review of a document is very important, yet in practice it can be challenging.  This document provides some best practices for getting document review; it does not define explicit mandatory steps.</p>
-<p>This page is linked to from <a rel="nofollow" class="external text" href="https://www.w3.org/Guide/">The Guide</a>. See also the <a href="https://www.w3.org/2020/Process-20200915/#wide-review">Wide Review</a> section in the W3C Process document.</p>
+<p>This page is linked to from <a rel="nofollow" class="external text" href="https://www.w3.org/Guide/">The Guide</a>. See also the <a href="https://www.w3.org/Consortium/Process/#wide-review">Wide Review</a> section in the W3C Process document.</p>
 <p><strong>Feedback on this document is welcome, preferably by <a href="https://github.com/w3c/documentreview/issues">raising an issue</a> or a pull request.</strong></p>
 <div id="toc">
 <h2 class="notoc">Contents</h2>
@@ -21,26 +21,97 @@
 
 
 
+<section id="when_should_review_be_requested">
+  <h2>When should wide review be requested?</h2>
+  <p>A document is available for review from the moment it is first <a
+  href='https://www.w3.org/Consortium/Process/#publishing'>published</a>.
+  Working Groups should <a
+  href='https://www.w3.org/Consortium/Process/#formally-addressed'>formally
+  address</a> any substantive review comment about a technical report in a
+  timely manner.</p>
+  <p>Wide review should or must be requested when:</p>
+  <ul>
+  <li>after a <a href="https://www.w3.org/Consortium/Process/#first-wd">First
+  Public Working Draft</a> is published for most documents.
+  <p>Working Groups are often reluctant to make substantive changes to a mature
+  document, so reviewers should get a chance to send substantive technical
+  reviews as early as possible. This is especially important for <a
+  href="#how_to_get_horizontal_review">horizontal reviews</a>.</p>
+  </li>
+  <li>Before a document gets advanced to <a
+  href="https://www.w3.org/Consortium/Process/#transition-cr">Candidate
+  Recommendation</a> or gets updated as a <a
+  href="https://www.w3.org/Consortium/Process/#update-requests">Candidate
+  Recommendation Snapshot</a>.
+  <p>For those, the <a href="https://www.w3.org/Consortium/Process/">W3C
+  Process</a> requires a Group to show that the specification has received wide
+  review.</p>
+  </li>
+  <li>When a document is both reasonably stable and still flexible enough to
+  allow changes where issues are identified</li>
+  <li>When new features are added after a document has already gotten wide
+  review (perhaps requesting a review limited to the new features)</li>
+  </ul>
+  </section>
 
 
 
 <section id="who_to_ask_for_review">
-<h2>Who to ask for review?</h2>
- 
-<p>Much of this document focuses on how and when to conduct horizontal reviews, but they are only a subset of a full wide review, which must also include other stakeholders including Web developers, technology providers and implementers not active in the Working Group, external groups and standards organizations working on related areas, etc. Here is a list of suggestions:</p>
+<h2>Who to ask for wide review?</h2>
+
+<p>The objective is to ensure that the entire set of stakeholders of the Web
+community, including the general public, have had adequate notice of the
+progress of the Working Group and were able to actually perform reviews of and
+provide comments on the specification. When considering <a
+href='https://www.w3.org/Guide/transitions'>requests to advance the maturity
+level of document</a>, the Director will consider who has been explicitly
+offered a reasonable opportunity to review the document.</p>
+
+<p>In order to include other stakeholders including Web developers, technology
+  providers and implementers not active in the Working Group, external groups and
+  standards organizations working on related areas, etc. you must:</p>
 <ul>
-<li> Groups listed in the WG's charter, especially those who manage dependencies.</li>
-<li> Groups jointly responsible for a particular document (if any)  (duh!).</li>
-<li> All horizontal groups (listed below).  If it appears that one of those is not relevant (and is not listed in your charter), talk to them informally to confirm that.</li>
-<li> Other groups, at your discretion, even if not in the WG charter, including other W3C groups, external organizations and SSOs, implementers, application developers, etc.</li>
-<li>The general public. Consider using blog posts, social media, or other ways of alerting the public to your document and requesting feedback.</li>
+  <li>Publish an updated technical report, with the Status of the Document indicating clearly
+  that you're looking for <em>wide review</em>.
+   <p>Our <a
+    href='https://github.com/w3c/transition-notifier/blob/main/notify.js'>tooling</a>
+    do pick up on publications and propagate to <a
+    href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>
+    automatically (for example, <a
+    href='https://lists.w3.org/Archives/Public/public-review-announce/2021Jun/0008.html'>Candidate
+    Recommendation Snapshot: Payment Request API (Call for Wide Review)</a>).</p>
+  </li>
+  <li>Reach out to the Groups listed in the WG's charter, especially those who
+  manage dependencies.</li>
+  <li>Reach out to the Groups jointly responsible for a particular document (if any).</li>
+  <li>Get reviews from the <a
+    href="#how_to_get_horizontal_review">horizontal groups</a>.</li>
+  <li>Reach out to the general public. Beyond the publication, you do so by:
+    <ol>
+      <li>Sending a dedicated announcement to <a
+      href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a>
+      if needed (in case the default notice sent to that list is
+      not enough).
+      </li>
+      <li>Considering using blog posts, social media, or other ways
+    of alerting the public to your document and requesting feedback.</li>
 </ul>
-<p>Use <a rel="nofollow" class="external text" href="mailto:public-review-announce@w3.org">public-review-announce@w3.org</a> for general announcements regarding wide and horizontal reviews. <em>However, note that sending an email to this list alone is not sufficient to trigger horizontal reviews. You will still need to formally request review from the Horizontal Groups, as described below.</em></p>
+
+<p>In addition, you should consider reaching out to other groups, at your
+discretion, even if not in the WG charter, including other W3C groups, external
+organizations and SSOs, implementers, application developers, etc.</p>
+
+<p><strong>Tip:</strong> consider tracking your wide review progress using a
+GitHub issue, such as <a href="https://github.com/w3c/sensors/issues/299">issue
+#299 of th Sensors API</a>. You can then simply point the Director to the issue.</p>
+
+
+<p>The reviews provided by the <a
+href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal
+groups</a>, a subset of a full wide review, do receive special attention and
+much of the rest of this document focuses on how and when to conduct horizontal reviews.</p>
+
 </section>
-
-
-
-
 
 <section id="how_to_get_horizontal_review">
 <h2>How to get horizontal review</h2>
@@ -92,8 +163,6 @@
 </details>
 </dd>
 
-
-
 <dt>Privacy</dt>
 <dd>Write a "Privacy Considerations" section for your document, taking into account the <a rel="nofollow" class="external text" href="https://w3ctag.github.io/security-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>, <a rel="nofollow" class="external text" href="https://w3c.github.io/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a>, and <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973">RFC6973</a> then <a rel="nofollow" class="external text" href="https://github.com/w3cping/privacy-request/issues/new/choose">request a review via GitHub</a> from the <a rel="nofollow" class="external text" href="https://www.w3.org/Privacy/">Privacy Interest Group</a>.
 <details>
@@ -131,24 +200,6 @@
 <p>You should familiarize yourself with the rest of this document. This section is just a quick reminder for when you are in the middle of doing the work.</p>
 <p>Recognize that horizontal review groups may be resource limited and may only be able to do one review or may have difficulty scheduling your review quickly.  Give them as much time as you can, consistent with asking for review while it is still reasonable to change the technology to accommodate the issues they find.</p>
 </section>
-
-
-
-
-
-<section id="when_should_review_be_requested">
-<h2>When should review be requested?</h2>
-<ul>
-<li>For most documents, after a <em>First Public Working Draft</em> is published</li>
-<li> Process-2019 requires wide review before a document is published at CR (Candidate Recommendation)</li>
-<li> When a document is both reasonably stable and still flexible enough to allow changes where issues are identified</li>
-<li> When new features are added after a document has already gotten wide review (perhaps requesting a review limited to the new features)</li>
-</ul>
-</section>
-
-
-
-
 
 <section id="working_with_horizontal_review_labels">
 <h2><a href="#working_with_horizontal_review_labels">Working with Horizontal Review labels</a></h2>

--- a/index.html
+++ b/index.html
@@ -335,6 +335,6 @@ reviews.</p>
 <script>
 createtoc(3)
 </script>
-<script type="text/javascript" src="createGitHubIssue.js"></script>
+<script src="createGitHubIssue.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
  level of the document</a>, the Director will consider who has been explicitly
  offered a reasonable opportunity to review the document.</p>
 
-<p>You must publish an updated technical report, with the Status of the Document
+<p>You <strong>must</strong> publish an updated technical report, with the Status of the Document
 indicating clearly that you're looking for <em>wide review</em>, before inviting
 review from other stakeholders. Our <a
 href='https://github.com/w3c/transition-notifier/blob/main/notify.js'>tooling</a>

--- a/index.html
+++ b/index.html
@@ -105,11 +105,23 @@ etc.</li>
 
 </ul>
 
+<aside id='using_github_issue'>
 <p><strong>Tip:</strong> consider tracking your wide review progress using a
 GitHub issue, such as <a href="https://github.com/w3c/sensors/issues/299">issue
 #299 of the Sensors API</a>. You can then simply point the Director to the
 issue.</p>
 
+<details id="githubissue" hidden>
+  <summary>Generate a meta-issue to track wide review steps in a GitHub repository</summary>
+  <p>You may find it useful to create an issue in the GitHub repository of your spec to track your progress. Add the name of your GitHub repository to the field below and hit the "Create GitHub issue" button. This opens the "new issue" form in your repository, and pre-fills the body with review steps as a list of checkboxes.</p>
+  <p>
+    <label for="repository">GitHub repository where issue should be created (format: <code>owner/repo</code>):</label>
+    <br/><input type="text" name="repository" id="repository" placeholder="Repo name, e.g. w3c/documentreview">
+    <br/><button>Create GitHub issue</button>
+  </p>
+  <p>Note: You will be able to edit the issue's title and body before it gets created.</p>
+</details>
+</aside>
 
 <p>The reviews provided by the <a
 href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal
@@ -213,17 +225,6 @@ reviews.</p>
 </details>
 </dd>
 </dl>
-
-<details id="githubissue" hidden>
-  <summary>Generate a meta-issue to track horizontal review steps in a GitHub repository</summary>
-  <p>You may find it useful to create an issue in the GitHub repository of your spec to track your progress. Add the name of your GitHub repository to the field below and hit the "Create GitHub issue" button. This opens the "new issue" form in your repository, and pre-fills the body with horizontal review steps as a list of checkboxes.</p>
-  <p>
-    <label for="repository">GitHub repository where issue should be created (format: <code>owner/repo</code>):</label>
-    <br/><input type="text" name="repository" id="repository" placeholder="Repo name, e.g. w3c/documentreview">
-    <br/><button>Create GitHub issue</button>
-  </p>
-  <p>Note: You will be able to edit the issue's title and body before it gets created.</p>
-</details>
 
 <p>You should familiarize yourself with the rest of this document. This section is just a quick reminder for when you are in the middle of doing the work.</p>
 <p>Recognize that horizontal review groups may be resource limited and may only be able to do one review or may have difficulty scheduling your review quickly.  Give them as much time as you can, consistent with asking for review while it is still reasonable to change the technology to accommodate the issues they find.</p>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 
 <p>The objective is to ensure that the entire set of stakeholders of the Web
 community, including the general public, have had adequate notice of the
-progress of the Working Group and were able to actually perform reviews of and
+progress of the Working Group and were genuinely able to perform reviews of and
 provide comments on the specification. When considering <a
 href='https://www.w3.org/Guide/transitions'>requests to advance the maturity
 level of document</a>, the Director will consider who has been explicitly

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   timely manner.</p>
   <p>Wide review should or must be requested:</p>
   <ul>
-  <li>after a <a href="https://www.w3.org/Consortium/Process/#first-wd">First
+  <li>After a <a href="https://www.w3.org/Consortium/Process/#first-wd">First
   Public Working Draft</a> is published for most documents.
   <p>Working Groups are often reluctant to make substantive changes to a mature
   document, so reviewers should get a chance to send substantive technical

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   <p>Wide review should or must be requested:</p>
   <ul>
   <li>After a <a href="https://www.w3.org/Consortium/Process/#first-wd">First
-  Public Working Draft</a> is published for most documents.
+  Public Working Draft</a> is published (for most documents).
   <p>Working Groups are often reluctant to make substantive changes to a mature
   document, so reviewers should get a chance to send substantive technical
   reviews as early as possible. This is especially important for <a

--- a/index.html
+++ b/index.html
@@ -82,12 +82,10 @@ Recommendation Snapshot: Payment Request API (Call for Wide Review)</a>).</p>
 dependencies.</li>
 <li>the groups jointly responsible for a particular document (if any).</li>
 <li>the <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal groups</a>
-using the <a href="#how_to_get_horizontal_review">method described below</a>.  If it
-appears that one of those is not relevant (even if not listed in your charter),
-talk to them informally to confirm that. <em>Note that sending an email to the
-public-review-announce list alone is not sufficient to trigger horizontal
-reviews. You will still need to formally request review from the Horizontal
-Groups, as described below</em></li>
+using the <a href="#how_to_get_horizontal_review">method described below</a>.
+<em>Note that sending an email to the public-review-announce list alone is not
+sufficient to trigger horizontal reviews. You will still need to formally
+request review from the Horizontal Groups, as described below</em></li>
 <li>the general public,  including Web developers, technology providers and
 implementers, application developers, etc. Consider:
   <ul>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 
  <p>The objective is to ensure that the entire set of stakeholders of the Web
  community, including the general public, have  adequate notice of the progress
- of the Working Group and are able to actually perform reviews of and provide
+ of the Working Group and are genuinely able to perform reviews of and provide
  comments on the specification. When considering <a
  href="https://www.w3.org/Guide/transitions">requests to advance the maturity
  level of the document</a>, the Director will consider who has been explicitly


### PR DESCRIPTION
This clarifies further how to get wide review (#12).

* clarify that publishing an updated technical report is expected as part of getting wide review, to discourage Groups to use their editor's drafts for that purpose (and it amplifies the reach to the public).
* our tooling will pick up if a publication is interested in wide review.
* as a tip, Groups should consider creating a GitHub issue to track the state of an ongoing wide review.

Hopefully this helps.

cc @nigelmegitt @frivoal @fantasai

-----

[Preview](https://htmlpreview.github.io/?https://raw.githubusercontent.com/w3c/documentreview/wide-review-42/index.html), [HTML diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FGuide%2Fdocumentreview%2F&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fdocumentreview%2Fwide-review-42%2Findex.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/documentreview/pull/21.html" title="Last updated on Oct 26, 2023, 5:47 PM UTC (851fb38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/documentreview/21/3393806...851fb38.html" title="Last updated on Oct 26, 2023, 5:47 PM UTC (851fb38)">Diff</a>