### PR TITLE
evergreen link for process

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body>
 <h1>How to do Wide Review</h1>
 <p>Getting <i class="term">early</i> and <i class="term">wide</i> review of a document is very important, yet in practice it can be challenging.  This document provides some best practices for getting document review; it does not define explicit mandatory steps.</p>
-<p>This page is linked to from <a rel="nofollow" class="external text" href="https://www.w3.org/Guide/">The Guide</a>. See also the <a href="https://www.w3.org/2020/Process-20200915/#wide-review">Wide Review</a> section in the W3C Process document.</p>
+<p>This page is linked to from <a rel="nofollow" class="external text" href="https://www.w3.org/Guide/">The Guide</a>. See also the <a href="https://www.w3.org/Consortium/Process/#wide-review">Wide Review</a> section in the W3C Process document.</p>
 <p><strong>Feedback on this document is welcome, preferably by <a href="https://github.com/w3c/documentreview/issues">raising an issue</a> or a pull request.</strong></p>
 <div id="toc">
 <h2 class="notoc">Contents</h2>


### PR DESCRIPTION
The link that goes to "wide review" in the process document is the dated one. When we adopt a new process it will be stale. 
Assuming future process documents continue to have a "wide review" section, using the generic link for the process document will always point to the most recent document.