### PR TITLE
change "tracker boards" to "issue trackers"

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,8 +202,8 @@
 
 
 <section id="horizontal_review_boards">
-<h2><a href="#horizontal_review_boards">Horizontal review boards</a></h2>
-<p>The horizontal groups maintain repositories containing issues that track those raised in the WG repos. Key information about the current state of those tracker repositories is reflected in a <a rel="nofollow" class="external text" href="https://w3c.github.io/horizontal-issue-tracker/index">set of tracker boards</a>, one per horizontal function. The board points to WG issues and the corresponding tracker issues, and groups issues by specification.
+<h2><a href="#horizontal_review_boards">Issue trackers</a></h2>
+<p>The horizontal groups maintain repositories containing issues that track those raised in the WG repos. You can see a list of tracked issues on the <a rel="nofollow" class="external text" href="https://w3c.github.io/horizontal-issue-tracker/index">tracker boards</a>, one per horizontal area.
 </p><p>Horizontal groups participants can find <a rel="nofollow" class="external text" href="https://w3c.github.io/horizontal-issue-tracker/HOWTO">detailed process information here</a>.</p>
 </section>
 


### PR DESCRIPTION
the "boards" language is non-intuitive for me.  Generally trimmed that section.