### PR TITLE
Cite published /TR versions where they exist

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 <li> links
 <ul><li> <a rel="nofollow" class="external text" href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/">Guidelines for creating web platform compatible components</a></li>
 <li> <a rel="nofollow" class="external text" href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a></li>
-<li> <a rel="nofollow" class="external text" href="https://w3ctag.github.io/design-principles/">Client-side API Design Principles</a></li>
+<li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/design-principles/">Client-side API Design Principles</a></li>
 <li> <a rel="nofollow" class="external text" href="https://www.w3.org/2001/tag/doc/capability-urls/">Good Practices for Capability URLs</a></li>
 <li> <a rel="nofollow" class="external text" href="https://github.com/w3ctag/design-reviews">TAG Repository for reviews</a></li></ul></li></ul>
 </details>
@@ -84,7 +84,7 @@
 <dt>Internationalisation</dt>
 <dd>
   <span class="step">Read the <a rel="nofollow" class="external text" href="https://www.w3.org/International/review-request">Request a review</a> page</span>, then
-  <span class="step">work through the <a rel="nofollow" class="external text" href="https://w3c.github.io/i18n-drafts/techniques/shortchecklist">Short Checklist</a></span>, then
+  <span class="step">work through the <a rel="nofollow" class="external text" href="https://www.w3.org/International/i18n-drafts/techniques/shortchecklist">Short Checklist</a></span>, then
   <span class="step"><a rel="nofollow" class="external text" href="https://github.com/w3c/i18n-request/issues/new/choose">request a review via GitHub</a></span>.
 <details>
 <summary>Show useful links</summary>
@@ -92,8 +92,8 @@
 <ul><li><a rel="nofollow" class="external text" href="https://www.w3.org/International/">Internationalization Working Group</a>; <a rel="nofollow" class="external text" href="https://lists.w3.org/Archives/Public/www-international/">www-international</a> Reviews by Internationalization generally also involve the <a rel="nofollow" class="external text" href="https://www.w3.org/International/ig/">Interest Group</a>, but are arranged through the WG.</li></ul></li>
 <li> links
 <ul><li><a rel="nofollow" class="external text" href="https://www.w3.org/International/review-request">Request a review</a></li>
-<li><a rel="nofollow" class="external text" href="https://w3c.github.io/i18n-drafts/techniques/shortchecklist">Self-Review Questionnaire</a>.</li>
-<li><a rel="nofollow" class="external text" href="https://www.w3.org/International/techniques/developing-specs">Detailed, expanding-collapsing checklist</a>, generated from <a rel="nofollow" class="external text" href="https://w3c.github.io/bp-i18n-specdev/"><cite>Internationalization Best Practices for Spec Developers</cite></a></li>
+<li><a rel="nofollow" class="external text" href="https://www.w3.org/International/i18n-drafts/techniques/shortchecklist">Self-Review Questionnaire</a>.</li>
+<li><a rel="nofollow" class="external text" href="https://www.w3.org/International/techniques/developing-specs">Detailed, expanding-collapsing checklist</a>, generated from <a rel="nofollow" class="external text" href="https://www.w3.org/TR/international-specs/"><cite>Internationalization Best Practices for Spec Developers</cite></a></li>
 <li> <a rel="nofollow" class="external text" href="https://www.w3.org/International/reviews/projReview.html">A brief overview of the review process</a> (with pictures)</li>
 <li> The <a rel="nofollow" class="external text" href="https://github.com/w3c/i18n-request/projects/1">Review Radar</a> shows the status of open reviews.</li></ul></li></ul>
 </details>
@@ -103,15 +103,15 @@
 
 <dt>Privacy</dt>
 <dd>
-  <span class="step">Write a "Privacy Considerations" section for your document, taking into account the <a rel="nofollow" class="external text" href="https://w3ctag.github.io/security-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>, <a rel="nofollow" class="external text" href="https://w3c.github.io/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a>, and <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973">RFC6973</a></span> then
+  <span class="step">Write a "Privacy Considerations" section for your document, taking into account the <a rel="nofollow" class="external text" href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>, <a rel="nofollow" class="external text" href="https://www.w3.org/TR/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a>, and <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973">RFC6973</a></span> then
   <span class="step"><a rel="nofollow" class="external text" href="https://github.com/w3cping/privacy-request/issues/new/choose">request a review via GitHub</a> from the <a rel="nofollow" class="external text" href="https://www.w3.org/Privacy/">Privacy Interest Group</a></span>.
 <details>
 <summary>Show useful links</summary>
 <ul><li>groups
 <ul><li> <a rel="nofollow" class="external text" href="https://www.w3.org/Privacy/">Privacy Interest Group</a>; <a rel="nofollow" class="external text" href="https://lists.w3.org/Archives/Public/public-privacy/">public-privacy</a></li></ul></li>
 <li> links
-<ul><li> <a rel="nofollow" class="external text" href="https://w3ctag.github.io/security-questionnaire/"><cite>Self-Review Questionnaire: Security and Privacy</cite>, published by the TAG and PING</a></li>
-<li> <a rel="nofollow" class="external text" href="https://w3c.github.io/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a></li>
+<ul><li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/security-privacy-questionnaire/"><cite>Self-Review Questionnaire: Security and Privacy</cite>, published by the TAG and PING</a></li>
+<li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a></li>
   <li> <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973">Privacy Considerations for Internet Protocols (RFC6973)</a>, particularly <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973#section-7">Section 7</a></li>
 <li> <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552">Guidelines for Writing RFC Text on Security Considerations (RFC3552)</a>, particularly <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552#section-5">Section 5</a></li>
 
@@ -124,7 +124,7 @@
 
 <dt>Security</dt>
 <dd>
-  <span class="step">Write a "Security Considerations" section for your document, taking into account the <a rel="nofollow" class="external text" href="https://w3ctag.github.io/security-questionnaire/">Self-Review Questionnaire: Security and Privacy</a></span>, then
+  <span class="step">Write a "Security Considerations" section for your document, taking into account the <a rel="nofollow" class="external text" href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a></span>, then
   <span class="step"><a rel="nofollow" class="external text" href="https://github.com/w3c/security-request/issues/new/choose">request a review via GitHub</a></span>
 
 <details>
@@ -132,8 +132,8 @@
 <ul><li> groups
 <ul><li> None</li></ul></li>
 <li> links
-<ul><li> <a rel="nofollow" class="external text" href="https://w3ctag.github.io/security-questionnaire/"><cite>Self-Review Questionnaire: Security and Privacy</cite>, published by the TAG and PING</a></li>
-<li> <a rel="nofollow" class="external text" href="https://w3c.github.io/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a></li>
+<ul><li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/security-privacy-questionnaire/"><cite>Self-Review Questionnaire: Security and Privacy</cite>, published by the TAG and PING</a></li>
+<li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a></li>
 <li> <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552">Guidelines for Writing RFC Text on Security Considerations (RFC3552)</a>, particularly <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552#section-5">Section 5</a></li></ul></li></ul>
 </details>
 </dd>
@@ -175,7 +175,7 @@
 <section id="working_with_horizontal_review_labels">
 <h2><a href="#working_with_horizontal_review_labels">Working with Horizontal Review labels</a></h2>
 
-<p>Applying these labels doesn't replace the need to schedule a review of your spec at an appropriate time. (See <a rel="nofollow" class="external text" href="https://w3c.github.io/documentreview/#how_to_get_horizontal_review">How to Get Horizontal Review</a> above.) Horizontal groups participants can find <a rel="nofollow" class="external text" href="https://w3c.github.io/horizontal-issue-tracker/HOWTO">detailed process information here</a>.
+<p>Applying these labels doesn't replace the need to schedule a review of your spec at an appropriate time. (See <a rel="nofollow" class="external text" href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">How to Get Horizontal Review</a> above.) Horizontal groups participants can find <a rel="nofollow" class="external text" href="https://w3c.github.io/horizontal-issue-tracker/HOWTO">detailed process information here</a>.
 </p>
 
 <section id="day-to-day_use_of_labels">


### PR DESCRIPTION
When a document has been published on TR, that version should be cited, not an editor's draft.