### PR TITLE
Use rfc-editor.org URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 
 <dt>Privacy</dt>
 <dd>
-  <span class="step">Write a "Privacy Considerations" section for your document, taking into account the <a rel="nofollow" class="external text" href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>, <a rel="nofollow" class="external text" href="https://www.w3.org/TR/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a>, and <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973">RFC6973</a></span> then
+  <span class="step">Write a "Privacy Considerations" section for your document, taking into account the <a rel="nofollow" class="external text" href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>, <a rel="nofollow" class="external text" href="https://www.w3.org/TR/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a>, and <a rel="nofollow" class="external text" href="https://www.rfc-editor.org/rfc/rfc6973.html">RFC6973</a></span> then
   <span class="step"><a rel="nofollow" class="external text" href="https://github.com/w3cping/privacy-request/issues/new/choose">request a review via GitHub</a> from the <a rel="nofollow" class="external text" href="https://www.w3.org/Privacy/">Privacy Interest Group</a></span>.
 <details>
 <summary>Show useful links</summary>
@@ -112,8 +112,8 @@
 <li> links
 <ul><li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/security-privacy-questionnaire/"><cite>Self-Review Questionnaire: Security and Privacy</cite>, published by the TAG and PING</a></li>
 <li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a></li>
-  <li> <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973">Privacy Considerations for Internet Protocols (RFC6973)</a>, particularly <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc6973#section-7">Section 7</a></li>
-<li> <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552">Guidelines for Writing RFC Text on Security Considerations (RFC3552)</a>, particularly <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552#section-5">Section 5</a></li>
+  <li> <a rel="nofollow" class="external text" href="https://www.rfc-editor.org/rfc/rfc6973.html">Privacy Considerations for Internet Protocols (RFC6973)</a>, particularly <a rel="nofollow" class="external text" href="https://www.rfc-editor.org/rfc/rfc6973.html#section-7">Section 7</a></li>
+<li> <a rel="nofollow" class="external text" href="https://www.rfc-editor.org/rfc/rfc3552.html">Guidelines for Writing RFC Text on Security Considerations (RFC3552)</a>, particularly <a rel="nofollow" class="external text" href="https://www.rfc-editor.org/rfc/rfc3552.html#section-5">Section 5</a></li>
 
 </ul></li></ul>
 </details>
@@ -134,7 +134,7 @@
 <li> links
 <ul><li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/security-privacy-questionnaire/"><cite>Self-Review Questionnaire: Security and Privacy</cite>, published by the TAG and PING</a></li>
 <li> <a rel="nofollow" class="external text" href="https://www.w3.org/TR/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a></li>
-<li> <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552">Guidelines for Writing RFC Text on Security Considerations (RFC3552)</a>, particularly <a rel="nofollow" class="external text" href="https://tools.ietf.org/html/rfc3552#section-5">Section 5</a></li></ul></li></ul>
+<li> <a rel="nofollow" class="external text" href="https://www.rfc-editor.org/rfc/rfc3552.html">Guidelines for Writing RFC Text on Security Considerations (RFC3552)</a>, particularly <a rel="nofollow" class="external text" href="https://www.rfc-editor.org/rfc/rfc3552.html#section-5">Section 5</a></li></ul></li></ul>
 </details>
 </dd>
 </dl>


### PR DESCRIPTION
tools.ietf.org is no longer to be relied on per https://mailarchive.ietf.org/arch/msg/tools-discuss/oYrAxb3KayPzZ4SNB1DVZTDPPNo/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/documentreview/pull/30.html" title="Last updated on Jun 15, 2022, 4:43 AM UTC (5072bef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/documentreview/30/f275235...5072bef.html" title="Last updated on Jun 15, 2022, 4:43 AM UTC (5072bef)">Diff</a>