### PR TITLE
Remove deprecated link to i18n specdev

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 <li> links
 <ul><li><a rel="nofollow" class="external text" href="https://www.w3.org/International/review-request">Request a review</a></li>
 <li><a rel="nofollow" class="external text" href="https://www.w3.org/International/i18n-drafts/techniques/shortchecklist">Self-Review Questionnaire</a>.</li>
-<li><a rel="nofollow" class="external text" href="https://www.w3.org/International/techniques/developing-specs">Detailed, expanding-collapsing checklist</a>, generated from <a rel="nofollow" class="external text" href="https://www.w3.org/TR/international-specs/"><cite>Internationalization Best Practices for Spec Developers</cite></a></li>
+<li><a rel="nofollow" class="external text" href="https://www.w3.org/TR/international-specs/">Internationalization Best Practices for Spec Developers</a></li>
 <li> <a rel="nofollow" class="external text" href="https://www.w3.org/International/reviews/projReview.html">A brief overview of the review process</a> (with pictures)</li>
 <li> The <a rel="nofollow" class="external text" href="https://github.com/w3c/i18n-request/projects/1">Review Radar</a> shows the status of open reviews.</li></ul></li></ul>
 </details>


### PR DESCRIPTION
cc @r12a


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/documentreview/pull/32.html" title="Last updated on Nov 10, 2022, 8:49 AM UTC (ddf32ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/documentreview/32/474394f...ddf32ac.html" title="Last updated on Nov 10, 2022, 8:49 AM UTC (ddf32ac)">Diff</a>